### PR TITLE
[Feat] 통계데이터 로직 추가 구현 (#49)

### DIFF
--- a/crm/src/main/java/com/encore/thecatch/complaint/controller/ComplaintController.java
+++ b/crm/src/main/java/com/encore/thecatch/complaint/controller/ComplaintController.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/complaints")
 @RequiredArgsConstructor
@@ -82,5 +84,17 @@ public class ComplaintController {
     public ResponseDto deleteComplaint(@PathVariable Long id) {
         Complaint complaint = complaintService.deletePost(id);
         return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS_DELETE_MY_POST, new DefaultResponse<Long>(complaint.getId()));
+    }
+
+    @GetMapping("/countAll")
+    public ResponseDto countAllComplaint(){
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS,
+                new DefaultResponse<Long>(complaintService.countAllComplaint()));
+    }
+
+    @GetMapping("/countStatus")
+    public ResponseDto countStatusComplaint(){
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS,
+                new DefaultResponse<List<CountStatusComplaintRes>>(complaintService.countStatusComplaint()));
     }
 }

--- a/crm/src/main/java/com/encore/thecatch/complaint/dto/response/CountAllComplaintRes.java
+++ b/crm/src/main/java/com/encore/thecatch/complaint/dto/response/CountAllComplaintRes.java
@@ -1,0 +1,14 @@
+package com.encore.thecatch.complaint.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class CountAllComplaintRes {
+    private Long count;
+
+    @QueryProjection
+    public CountAllComplaintRes (Long count) {
+        this.count = count;
+    }
+}

--- a/crm/src/main/java/com/encore/thecatch/complaint/dto/response/CountStatusComplaintRes.java
+++ b/crm/src/main/java/com/encore/thecatch/complaint/dto/response/CountStatusComplaintRes.java
@@ -1,0 +1,14 @@
+package com.encore.thecatch.complaint.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class CountStatusComplaintRes {
+    private Long count;
+
+    @QueryProjection
+    public CountStatusComplaintRes(Long count) {
+        this.count = count;
+    }
+}

--- a/crm/src/main/java/com/encore/thecatch/complaint/repository/ComplaintQueryRepository.java
+++ b/crm/src/main/java/com/encore/thecatch/complaint/repository/ComplaintQueryRepository.java
@@ -3,8 +3,7 @@ package com.encore.thecatch.complaint.repository;
 
 import com.encore.thecatch.common.util.AesUtil;
 import com.encore.thecatch.complaint.dto.request.SearchComplaintCondition;
-import com.encore.thecatch.complaint.dto.response.ListComplaintRes;
-import com.encore.thecatch.complaint.dto.response.QListComplaintRes;
+import com.encore.thecatch.complaint.dto.response.*;
 import com.encore.thecatch.complaint.entity.QComplaint;
 import com.encore.thecatch.complaint.entity.Status;
 import com.encore.thecatch.user.domain.QUser;
@@ -43,6 +42,25 @@ public class ComplaintQueryRepository {
                         eqStatus(searchComplaintCondition.getStatus()),
                         complaint.active.eq(true))
                 .orderBy(complaint.status.asc(), complaint.createdTime.asc())
+                .fetch();
+    }
+
+    public Long countAllComplaint() {
+        return queryFactory
+                .select(new QCountAllComplaintRes(
+                        complaint.count()))
+                .from(complaint)
+                .where(complaint.active.eq(true))
+                .fetchCount();
+    }
+
+    public List<CountStatusComplaintRes> countStatusComplaint() {
+        return queryFactory
+                .select(new QCountStatusComplaintRes(
+                        complaint.count()).as("count"))
+                .from(complaint)
+                .where(complaint.active.eq(true))
+                .groupBy(complaint.status)
                 .fetch();
     }
 

--- a/crm/src/main/java/com/encore/thecatch/complaint/service/ComplaintService.java
+++ b/crm/src/main/java/com/encore/thecatch/complaint/service/ComplaintService.java
@@ -142,7 +142,7 @@ public class ComplaintService {
         s3Service.deleteFile(imageKey);
     }
 
-    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('CS') or hasAuthority('MARKETER')")
+    @PreAuthorize("hasAnyAuthority('ADMIN','CS','MARKETER')")
     public Page<ListComplaintRes> searchComplaint(SearchComplaintCondition searchComplaintCondition, Pageable pageable) throws Exception {
         List<ListComplaintRes> listComplaintRes = complaintQueryRepository.findComplaintList(searchComplaintCondition);
         List<ListComplaintRes> listComplaintRes1 = new ArrayList<>();

--- a/crm/src/main/java/com/encore/thecatch/complaint/service/ComplaintService.java
+++ b/crm/src/main/java/com/encore/thecatch/complaint/service/ComplaintService.java
@@ -142,7 +142,7 @@ public class ComplaintService {
         s3Service.deleteFile(imageKey);
     }
 
-    @PreAuthorize("hasAuthority('ADMIN')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('CS') or hasAuthority('MARKETER')")
     public Page<ListComplaintRes> searchComplaint(SearchComplaintCondition searchComplaintCondition, Pageable pageable) throws Exception {
         List<ListComplaintRes> listComplaintRes = complaintQueryRepository.findComplaintList(searchComplaintCondition);
         List<ListComplaintRes> listComplaintRes1 = new ArrayList<>();
@@ -160,5 +160,14 @@ public class ComplaintService {
         int end = Math.min((start + pageable.getPageSize()), listComplaintRes1.size());
 
         return new PageImpl<>(listComplaintRes1.subList(start, end), pageable, listComplaintRes.size());
+    }
+
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('CS') or hasAuthority('MARKETER')")
+    public Long countAllComplaint() {
+        return complaintQueryRepository.countAllComplaint();
+    }
+
+    public List<CountStatusComplaintRes> countStatusComplaint() {
+        return  complaintQueryRepository.countStatusComplaint();
     }
 }

--- a/crm/src/main/java/com/encore/thecatch/coupon/controller/CouponController.java
+++ b/crm/src/main/java/com/encore/thecatch/coupon/controller/CouponController.java
@@ -22,24 +22,24 @@ public class CouponController {
     private final CouponService couponService;
 
     @Autowired
-    public CouponController(CouponService couponService){
+    public CouponController(CouponService couponService) {
         this.couponService = couponService;
     }
 
     @PostMapping("/create")
-    public ResponseDto couponCreate(@RequestBody CouponReqDto couponReqDto) throws Exception{
+    public ResponseDto couponCreate(@RequestBody CouponReqDto couponReqDto) throws Exception {
         Coupon coupon = couponService.create(couponReqDto);
         return new ResponseDto(HttpStatus.CREATED, ResponseCode.SUCCESS_CREATE_COUPON, new DefaultResponse<Long>(coupon.getId()));
     }
 
     @PatchMapping("/{id}/publish")
-    public ResponseDto couponPublish(@PathVariable Long id){
+    public ResponseDto couponPublish(@PathVariable Long id) {
         Coupon coupon = couponService.publish(id);
         return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS_PUBLISH_COUPON, new DefaultResponse<Long>(coupon.getId()));
     }
 
     @PatchMapping("/receive")
-    public ResponseDto couponReceive(@RequestBody CouponReceiveDto couponReceiveDto){
+    public ResponseDto couponReceive(@RequestBody CouponReceiveDto couponReceiveDto) {
         Coupon coupon = couponService.receive(couponReceiveDto);
         return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS_RECEIVE_COUPON, new DefaultResponse<Long>(coupon.getId()));
     }
@@ -51,11 +51,12 @@ public class CouponController {
     }
 
     @PostMapping("/search")
-    public ResponseDto searchCoupon(@RequestBody SearchCouponCondition searchCouponCondition)throws Exception{
+    public ResponseDto searchCoupon(@RequestBody SearchCouponCondition searchCouponCondition) throws Exception {
         System.out.println(searchCouponCondition.getName());
         Pageable pageable = PageRequest.of(searchCouponCondition.getPageNo(), 10);
         return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS, new DefaultResponse<Page<CouponFindResDto>>(couponService.searchCoupon(searchCouponCondition, pageable)));
     }
+
     @GetMapping("/myList")
     public ResponseDto findMyAll() {
         List<CouponResDto> couponResDtos = couponService.findMyAll();
@@ -63,21 +64,25 @@ public class CouponController {
     }
 
     @GetMapping("/{id}")
-    public ResponseDto couponRead(@PathVariable Long id){
+    public ResponseDto couponRead(@PathVariable Long id) {
         return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS, new DefaultResponse<CouponResDto>(couponService.findById(id)));
     }
 
 
     @PatchMapping("/{id}/update")
-    public ResponseDto couponUpdate(@PathVariable Long id, @RequestBody CouponReqDto couponReqDto){
+    public ResponseDto couponUpdate(@PathVariable Long id, @RequestBody CouponReqDto couponReqDto) {
         Coupon coupon = couponService.couponUpdate(id, couponReqDto);
-        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS , new DefaultResponse<Long>(coupon.getId()));
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS, new DefaultResponse<Long>(coupon.getId()));
     }
 
     @PatchMapping("/{id}/delete")
-    public ResponseDto couponDelete(@PathVariable Long id){
+    public ResponseDto couponDelete(@PathVariable Long id) {
         couponService.couponDelete(id);
         return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS_DELETE_COUPON, new DefaultResponse<Long>(id));
     }
 
+    @GetMapping("/publish/count")
+    public ResponseDto couponPublishCount() {
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS, new DefaultResponse<Long>(couponService.couponPublishCount()));
+    }
 }

--- a/crm/src/main/java/com/encore/thecatch/coupon/dto/CouponPublishCountRes.java
+++ b/crm/src/main/java/com/encore/thecatch/coupon/dto/CouponPublishCountRes.java
@@ -1,0 +1,14 @@
+package com.encore.thecatch.coupon.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class CouponPublishCountRes {
+    private Long count;
+
+    @QueryProjection
+    public CouponPublishCountRes(Long count){
+        this.count = count;
+    }
+}

--- a/crm/src/main/java/com/encore/thecatch/coupon/repository/CouponQueryRepository.java
+++ b/crm/src/main/java/com/encore/thecatch/coupon/repository/CouponQueryRepository.java
@@ -5,6 +5,7 @@ import com.encore.thecatch.coupon.domain.CouponStatus;
 import com.encore.thecatch.coupon.domain.QCoupon;
 import com.encore.thecatch.coupon.dto.CouponFindResDto;
 import com.encore.thecatch.coupon.dto.QCouponFindResDto;
+import com.encore.thecatch.coupon.dto.QCouponPublishCountRes;
 import com.encore.thecatch.coupon.dto.SearchCouponCondition;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -44,6 +45,17 @@ public class CouponQueryRepository {
                         eqStatus(searchCouponCondition.getCouponStatus()))
                 .fetch();
     }
+
+    public Long couponPublishCount() {
+        return queryFactory
+                .select(new QCouponPublishCountRes(
+                        coupon.count().as("count")
+                ))
+                .from(coupon)
+                .where(coupon.couponStatus.eq(CouponStatus.PUBLISH))
+                .fetchCount();
+    }
+
         private BooleanExpression eqName(String name) throws Exception {
         return hasText(name) ? coupon.name.eq(name) : null;
     }

--- a/crm/src/main/java/com/encore/thecatch/coupon/service/CouponService.java
+++ b/crm/src/main/java/com/encore/thecatch/coupon/service/CouponService.java
@@ -187,4 +187,8 @@ public class CouponService {
         }
         return coupon;
     }
+
+    public Long couponPublishCount() {
+        return couponQueryRepository.couponPublishCount();
+    }
 }

--- a/crm/src/main/java/com/encore/thecatch/log/controller/LogController.java
+++ b/crm/src/main/java/com/encore/thecatch/log/controller/LogController.java
@@ -1,0 +1,59 @@
+package com.encore.thecatch.log.controller;
+
+import com.encore.thecatch.common.DefaultResponse;
+import com.encore.thecatch.common.ResponseCode;
+import com.encore.thecatch.common.dto.ResponseDto;
+import com.encore.thecatch.log.dto.DayOfWeekLogin;
+import com.encore.thecatch.log.service.LogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/log")
+public class LogController {
+
+    private final LogService logService;
+
+    //고객 총 방문 수
+    @GetMapping("/visit/total")
+    public ResponseDto visitTotalUser(){
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS
+                , new DefaultResponse<Long>(logService.visitTotalUser()));
+    }
+
+    //고객 오늘 총 방문 수
+    @GetMapping("/visit/today")
+    public ResponseDto visitToday(){
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS
+                , new DefaultResponse<Long>(logService.visitToday()));
+    }
+
+    //고객 오늘 실 방문수
+    @GetMapping("/visit/today/user")
+    public ResponseDto visitTodayUser(){
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS
+                , new DefaultResponse<Long>(logService.visitTodayUserCount()));
+    }
+
+    //고객 지난주 요일별 방문수
+    @GetMapping("/visit/week/user")
+    public ResponseDto dayOfWeekLogin(){
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS
+                , new DefaultResponse<List<DayOfWeekLogin>>(logService.dayOfWeekLogin()));
+    }
+
+
+
+    //이메일 총 발송 건수
+    @GetMapping("/email/total")
+    public ResponseDto totalEmail(){
+        return new ResponseDto(HttpStatus.OK, ResponseCode.SUCCESS
+                , new DefaultResponse<Long>(logService.totalEmail()));
+    }
+}

--- a/crm/src/main/java/com/encore/thecatch/log/dto/DayOfWeekLogin.java
+++ b/crm/src/main/java/com/encore/thecatch/log/dto/DayOfWeekLogin.java
@@ -1,0 +1,18 @@
+package com.encore.thecatch.log.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class DayOfWeekLogin {
+    private String day;
+    private Long count;
+
+    @QueryProjection
+    public DayOfWeekLogin (String day, Long count) {
+        this.day = day;
+        this.count = count;
+    }
+}

--- a/crm/src/main/java/com/encore/thecatch/log/dto/VisitTodayUserRes.java
+++ b/crm/src/main/java/com/encore/thecatch/log/dto/VisitTodayUserRes.java
@@ -1,0 +1,14 @@
+package com.encore.thecatch.log.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class VisitTodayUserRes {
+    private String email;
+
+    @QueryProjection
+    public VisitTodayUserRes(String email) {
+        this.email = email;
+    }
+}

--- a/crm/src/main/java/com/encore/thecatch/log/repository/EmailLogQueryRepository.java
+++ b/crm/src/main/java/com/encore/thecatch/log/repository/EmailLogQueryRepository.java
@@ -1,0 +1,21 @@
+package com.encore.thecatch.log.repository;
+
+import com.encore.thecatch.log.domain.QEmailLog;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailLogQueryRepository {
+    private final JPAQueryFactory queryFactory;
+    QEmailLog emailLog = QEmailLog.emailLog;
+
+    public Long totalEmail() {
+        return queryFactory
+                .select(
+                        emailLog.count())
+                .from(emailLog)
+                .fetchCount();
+    }
+}

--- a/crm/src/main/java/com/encore/thecatch/log/repository/UserLogQueryRepository.java
+++ b/crm/src/main/java/com/encore/thecatch/log/repository/UserLogQueryRepository.java
@@ -1,0 +1,71 @@
+package com.encore.thecatch.log.repository;
+
+import com.encore.thecatch.log.domain.QUserLog;
+import com.encore.thecatch.log.dto.DayOfWeekLogin;
+import com.encore.thecatch.log.dto.QDayOfWeekLogin;
+import com.encore.thecatch.log.dto.QVisitTodayUserRes;
+import com.encore.thecatch.log.dto.VisitTodayUserRes;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserLogQueryRepository {
+    private final JPAQueryFactory queryFactory;
+
+    QUserLog userLog = QUserLog.userLog;
+
+
+    public Long visitTotalUser() {
+        return queryFactory
+                .select(
+                        userLog.count())
+                .from(userLog)
+                .fetchCount();
+    }
+
+    public Long visitToday() {
+//        x.goe(y); (x >= y)
+//        x.loe(y); (x <= y)
+        return queryFactory
+                .select(
+                        userLog.count())
+                .from(userLog)
+                .where(userLog.createdTime.goe(LocalDateTime.of(LocalDate.now(), LocalTime.of(0,0, 0))),
+                        userLog.createdTime.loe(LocalDateTime.of(LocalDate.now(), LocalTime.of(12,59, 59))))
+                .fetchCount();
+    }
+
+    public List<VisitTodayUserRes> visitTodayUser() {
+        return queryFactory
+                .select(new QVisitTodayUserRes(userLog.email))
+                .distinct()
+                .from(userLog)
+                .where(userLog.createdTime.goe(LocalDateTime.of(LocalDate.now(), LocalTime.of(0,0, 0))),
+                        userLog.createdTime.loe(LocalDateTime.of(LocalDate.now(), LocalTime.of(12,59, 59))))
+                .fetch();
+    }
+
+    public List<DayOfWeekLogin> dayOfWeekLogin() {
+        LocalDate now = LocalDate.now();
+        LocalDate startOfLastWeek = now.minusWeeks(1).with(DayOfWeek.MONDAY);
+        LocalDate endOfLastWeek = now.minusWeeks(1).with(DayOfWeek.SUNDAY);
+
+        return queryFactory
+                .select(new QDayOfWeekLogin(
+                        userLog.createdTime.dayOfWeek().as("day").stringValue(),
+                        userLog.count()))
+                .from(userLog)
+                .where(userLog.createdTime.between(startOfLastWeek.atStartOfDay(), endOfLastWeek.atTime(23, 59, 59)))
+                .groupBy(userLog.createdTime.dayOfWeek())
+                .orderBy(userLog.createdTime.dayOfWeek().asc())
+                .fetch();
+    }
+}

--- a/crm/src/main/java/com/encore/thecatch/log/service/LogService.java
+++ b/crm/src/main/java/com/encore/thecatch/log/service/LogService.java
@@ -1,0 +1,41 @@
+package com.encore.thecatch.log.service;
+
+import com.encore.thecatch.log.dto.DayOfWeekLogin;
+import com.encore.thecatch.log.dto.VisitTodayUserRes;
+import com.encore.thecatch.log.repository.EmailLogQueryRepository;
+import com.encore.thecatch.log.repository.UserLogQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LogService {
+    private final UserLogQueryRepository userLogQueryRepository;
+    private final EmailLogQueryRepository emailLogQueryRepository;
+
+    public Long visitTotalUser() {
+        return userLogQueryRepository.visitTotalUser();
+    }
+
+    public Long visitToday() {
+        return userLogQueryRepository.visitToday();
+    }
+
+    public Long visitTodayUserCount() {
+        List<VisitTodayUserRes> list = userLogQueryRepository.visitTodayUser();
+        return (long) list.size();
+    }
+
+    public List<DayOfWeekLogin> dayOfWeekLogin() {
+        return userLogQueryRepository.dayOfWeekLogin();
+    }
+
+    public Long totalEmail() {
+        return emailLogQueryRepository.totalEmail();
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> * #49 

## 📝작업 내용

- 고객 금일 총 방문 수 로직 구현
- 고객 금일 실 방문자 수 로직 구현
- 총 게시글 수 로직 구현
- 게시글 답변 상태에 따른 게시글 수 로직 구현
- 발행중인 쿠폰 수 로직 구현
- 요일별 로그인 수 차트 로직 구현
